### PR TITLE
Correctly savestate std::maps with non-uint keys

### DIFF
--- a/Common/ChunkFile.h
+++ b/Common/ChunkFile.h
@@ -81,6 +81,12 @@ public:
 	template<class T>
 	void Do(std::map<unsigned int, T> &x)
 	{
+		Do<unsigned int, T>(x);
+	}
+
+	template<class K, class T>
+	void Do(std::map<K, T> &x)
+	{
 		unsigned int number = (unsigned int)x.size();
 		Do(number);
 		switch (mode) {
@@ -89,7 +95,7 @@ public:
 				x.clear();
 				while (number > 0)
 				{
-					unsigned int first = 0;
+					K first = 0;
 					Do(first);
 					T second;
 					Do(second);
@@ -102,7 +108,7 @@ public:
 		case MODE_MEASURE:
 		case MODE_VERIFY:
 			{
-				typename std::map<unsigned int, T>::iterator itr = x.begin();
+				typename std::map<K, T>::iterator itr = x.begin();
 				while (number > 0)
 				{
 					Do(itr->first);

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -197,7 +197,7 @@ void IntrHandler::queueUp(int subintr)
 void IntrHandler::DoState(PointerWrap &p)
 {
 	p.Do(intrNumber);
-	p.Do(subIntrHandlers);
+	p.Do<int, SubIntrHandler>(subIntrHandlers);
 }
 
 void __InterruptsInit()


### PR DESCRIPTION
Fixes savestates, seem to work now.

-[Unknown]
