### PR TITLE
Add missing Google Maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-       jcenter()
+	    google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'
@@ -10,6 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
+	    google()
         jcenter()
     }
 }


### PR DESCRIPTION
Gradle build tools have been moved to it. CLI builds fail without it.